### PR TITLE
fix EWOC feed

### DIFF
--- a/planet.ini
+++ b/planet.ini
@@ -110,7 +110,7 @@ title = DSA Chapters, National Working Groups, and Publications
 
 [dsausa-labor-ewoc]
  title    = Emergency Workplace Organizing Committee
- feed     = https://workerorganizing.org/feed
+ feed     = https://workerorganizing.org/feed/
  link     = https://workerorganizing.org/
  location = en
  avatar   = ewoc.png


### PR DESCRIPTION
Jekyll Feed Tests / build failing after "Non successful status code 301 when trying to access `https://workerorganizing.org/feed`"

https://workerorganizing.org/feed
404

https://workerorganizing.org/feed/
feed downloads

it seems like when working on #18 some consistent formatting should be applied