### PR TITLE
fix dsa labor feed url

### DIFF
--- a/planet.ini
+++ b/planet.ini
@@ -125,7 +125,7 @@ title = DSA Chapters, National Working Groups, and Publications
 
 [dsausa-labor]
  title     = DSA National Labor Commission
- feed      = https://labor.dsausa.org/feed/
+ feed      = https://labor.dsausa.org/news/feed/
  link      = https://labor.dsausa.org/
  location  = en
  avatar    = labor.jpg


### PR DESCRIPTION
dsa labor has their blog at /news, so the rss feed is at /news/feed