### PR TITLE
Bump CI Version Numbers

### DIFF
--- a/.github/workflows/feeds.yml
+++ b/.github/workflows/feeds.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install dependencies
-      uses: docker://ruby:3.1
+      uses: docker://ruby:3.3
       env:
         BUNDLE_PATH: .bundle
       with:
@@ -25,7 +25,7 @@ jobs:
         args: install -j=4
 
     - name: Run the tests
-      uses: docker://ruby:3.1
+      uses: docker://ruby:3.3
       env:
         BUNDLE_PATH: .bundle
         LANG: en_US.UTF-8

--- a/.github/workflows/feeds.yml
+++ b/.github/workflows/feeds.yml
@@ -5,8 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-
-
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
   schedule:
     # * is a special character in YAML so you have to quote this string
     # We will pull once a day, UTC to start to not blow up our Github actions

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install dependencies
-      uses: docker://ruby:3.1
+      uses: docker://ruby:3.3
       env:
         BUNDLE_PATH: .bundle
       with:
@@ -33,7 +33,7 @@ jobs:
         args: install -j=4
 
     - name: Fetch the content
-      uses: docker://ruby:3.1
+      uses: docker://ruby:3.3
       env:
         BUNDLE_PATH: .bundle
         LANG: en_US.UTF-8
@@ -44,7 +44,7 @@ jobs:
         args: exec rake
 
     - name: Build the site
-      uses: docker://ruby:3.1
+      uses: docker://ruby:3.3
       env:
         BUNDLE_PATH: .bundle
         LANG: en_US.UTF-8

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install dependencies
       uses: docker://ruby:3.1
@@ -55,7 +55,7 @@ jobs:
         args: exec jekyll build
     - name: Upload artifact
       # Automatically uploads an artifact from the './_site' directory by default
-      uses: actions/upload-pages-artifact@v2
+      uses: actions/upload-pages-artifact@v3
 
   # Deployment job
   deploy:
@@ -67,4 +67,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Does not seem to break anything and node16 is going away soon.
https://github.com/bmos/dsa-planet/actions/runs/8053957838/job/21997489715