### PR TITLE
fix: temporarily disable NLC

### DIFF
--- a/planet.ini
+++ b/planet.ini
@@ -123,12 +123,13 @@ title = DSA Chapters, National Working Groups, and Publications
  location = en
  avatar   = international.png
 
-[dsausa-labor]
- title     = DSA National Labor Commission
- feed      = https://labor.dsausa.org/news/feed/
- link      = https://labor.dsausa.org/
- location  = en
- avatar    = labor.jpg
+# Temporarily experiencing issues
+# [dsausa-labor]
+#  title     = DSA National Labor Commission
+#  feed      = https://labor.dsausa.org/news/feed/
+#  link      = https://labor.dsausa.org/
+#  location  = en
+#  avatar    = labor.jpg
 
 [dsausa-labor-ewoc]
  title    = Emergency Workplace Organizing Committee


### PR DESCRIPTION
they're having URL resolution issues, which is causing site builds to fail

example failing build: https://github.com/dsa-ntc/dsa-planet/actions/runs/8053379287/job/21995650933#step:5:30