### PR TITLE
Fix build: remove berkshires feed (SSLError)

### DIFF
--- a/planet.ini
+++ b/planet.ini
@@ -147,13 +147,6 @@ link = https://atldsa.org/
 location = en
 avatar = atlanta.webp
 
-[berkshiresdsa]
-title = Berkshires DSA
-feed = https://berkshiresdsa.org/feed
-link = https://berkshiresdsa.org/
-location = en
-avatar = berkshires.webp
-
 [boisedsa]
 title = Boise DSA
 feed = https://www.boisedsa.org/statements?format=rss


### PR DESCRIPTION
This PR removes the berkshires feed which appears to be down, causing a [broken build.](https://discussion.dsausa.org/t/introducing-dsa-feed-an-aggregator-for-dsa-publications-from-the-ntc/26877/14?u=erik-s)

I suspect [this is the issue](https://github.com/feedreader/pluto/issues/31) - with the pluto feedreader gem, which would require a fork or upstream pr to there. This particular error (`Faraday::SSLError`) from the tests is not caught and thus the build stops after atlanta.

