### PR TITLE
Disable las vegas dsa feed due to known issue with output

### DIFF
--- a/planet.ini
+++ b/planet.ini
@@ -311,14 +311,6 @@ link = https://houstondsa.org/
 location = en
 avatar = houston.webp
 
-#[lasvegasdsa]
-#title = Las Vegas DSA
-#feed = https://lvdsa.org/feed
-#link = https://lvdsa.org/
-#location = en
-#avatar = lasvegas.webp
-#email = lasvegasdsa@gmail.com
-
 [losangelesdsa]
 title = DSA Los Angeles
 feed = https://dsa-la.org/feed/

--- a/planet.ini
+++ b/planet.ini
@@ -311,13 +311,13 @@ link = https://houstondsa.org/
 location = en
 avatar = houston.webp
 
-[lasvegasdsa]
-title = Las Vegas DSA
-feed = https://lvdsa.org/feed
-link = https://lvdsa.org/
-location = en
-avatar = lasvegas.webp
-email = lasvegasdsa@gmail.com
+#[lasvegasdsa]
+#title = Las Vegas DSA
+#feed = https://lvdsa.org/feed
+#link = https://lvdsa.org/
+#location = en
+#avatar = lasvegas.webp
+#email = lasvegasdsa@gmail.com
 
 [losangelesdsa]
 title = DSA Los Angeles


### PR DESCRIPTION
lvdsa.org/feed is outputting entire text excerpt rather than summary for their RSS feed and the resulting output is being truncated at 70KB, resulting in an incomplete and malformed output. This is breaking the feed creation loop and resulting in articles from feeds further down in the planet.ini not being shown on https://feed.dsausa.org/

https://github.com/feedreader/pluto/blob/55a6b7fd4c7e0b73654bd436ad7056e29a389217/pluto-update/lib/pluto/update/feed_refresher.rb#L33

In the upstream pluto `feed_refresher` it is a known issue that exceptions are not caught in the `refresh_feed_worker` loop. We should be able to monkeypatch the class to implement a try catch block, but for now instead we can disable the lasvegasdsa

relevant discussion thread can be found on NTC forums at: https://discussion.dsausa.org/chat/c/-/36/11409
